### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ libraries.
 You can install from PyPI:
 
 ```
-$ python3 -m pip install TA-Lib
+$ python -m pip install TA-Lib
 ```
 
 Or checkout the sources and run ``setup.py`` yourself:


### PR DESCRIPTION
python3 -m pip install TA-Lib
is a old way 
now every one has python3 so use python directly
python -m pip install TA-Lib