### PR TITLE
Set path for Apple Silicon architectures

### DIFF
--- a/tools/install-macos.sh
+++ b/tools/install-macos.sh
@@ -1,4 +1,10 @@
 
 brew install ta-lib
 
+arch="$(uname -m)"
+if [ "$arch" = "arm64" ]; then
+  export TA_INCLUDE_PATH="$(brew --prefix ta-lib)/include"
+  export TA_LIBRARY_PATH="$(brew --prefix ta-lib)/lib"
+fi
+
 pip3 install ta-lib


### PR DESCRIPTION
Check if OS is of Apple Silicon architecture to prep pip install with the correct path.