### PR TITLE
Bump pre-built actions to their latest major version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,13 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         pip install --upgrade pip wheel
@@ -28,18 +30,21 @@ jobs:
         DEPS_PATH: ${{ github.workspace }}/dependencies
         TA_INCLUDE_PATH: ${{ github.workspace }}/dependencies/include
         TA_LIBRARY_PATH: ${{ github.workspace }}/dependencies/lib
+
     - name: Build cython modules in-place
       run: |
         python setup.py build_ext --inplace --include-dirs=$TA_INCLUDE_PATH --library-dirs=$TA_LIBRARY_PATH
       env:
         TA_INCLUDE_PATH: ${{ github.workspace }}/dependencies/include
         TA_LIBRARY_PATH: ${{ github.workspace }}/dependencies/lib
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         #flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
       run: |
         PYTHONPATH=. pytest


### PR DESCRIPTION
Bump pre-built actions to their latest major version

While it's not necessarily a problem to use older actions - it's better to use the latest version.

(on top of that, `setup-python@v4` now has a `allow-prereleases: true` flag - which will allow testing against 3.12 (which currently fails as `distutils` no longer exists - but is a topic for another time).