### PR TITLE
Add build-requires pinning numpy to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 51.0.0", "wheel"]
+requires = ["setuptools >= 51.0.0", "wheel", "numpy<2.0.0"]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
With the release of numpy2.0, ta-lib is no longer installable (the build fails), as it's currently incompatible with numpy 2.x.

While that should be addressed too - I'm not sure it's a "quick fix" that can be done with just a few lines of code (or while keeping compatibility with older numpy versions).

i therefore think it's better to have a "quick fix" available so it's at least not breaking existing setups / installations.
Regular version-pinning is not relevant here - as it's the numpy version during build-time (a separate, isolated environment created while building a package) that's the problem currently.

Temporarily solves #655

Alternative workarounds: Disable build isolation.

```
pip install "numpy<2"
pip install TA-Lib -v --no-build-isolation
```

---


To test this:
install ta-lib (regularly, without workaround) without this fix anytime after the numpy 2.x release (don't test while time-traveling, please) - notice it failing
Install with this fix - notice the build working again.