### PR TITLE
Add GitHub Actions workflow for automated Python wheel builds across multiple platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 env:
-  TALIB_C_VER: ${{ github.ref_name }}
+  TALIB_C_VER: 0.6.2
   TALIB_PY_VER: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc g++ cmake
       - name: Make script executable
-        run: chmod +x build_linux.sh
+        run: chmod +x ./tools/build_wheel_linux.sh
       - name: Build TA-Lib
         run: ./tools/build_wheel_linux.sh
         shell: bash
@@ -100,7 +100,7 @@ jobs:
             cmake
           volumes: ${{ github.workspace }}:/project
       - name: Make script executable
-        run: chmod +x build_linux.sh
+        run: chmod +x ./tools/build_wheel_linux.sh
       - name: Build TA-Lib
         run: |
           ./tools/build_wheel_linux.sh
@@ -224,7 +224,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Make script executable
-        run: chmod +x build_macos.sh
+        run: chmod +x ./tools/build_wheel_macos.sh
       - name: Build TA-Lib
         run: ./tools/build_wheel_macos.sh
         shell: bash
@@ -268,7 +268,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Make script executable
-        run: chmod +x build_macos.sh
+        run: chmod +x ./tools/build_wheel_macos.sh
       - name: Build TA-Lib
         run: ./tools/build_wheel_macos.sh
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,7 @@ jobs:
             PIP_NO_BUILD_ISOLATION=false
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             export MACOSX_DEPLOYMENT_TARGET=13.7
-            export DYLD_LIBRARY_PATH="/Users/runner/work/talib-prebuilt/talib-prebuilt/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
+            export DYLD_LIBRARY_PATH="/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
       - name: Set wheel name
         run: |
@@ -292,7 +292,7 @@ jobs:
             PIP_NO_BUILD_ISOLATION=false
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             export MACOSX_DEPLOYMENT_TARGET=14.0
-            export DYLD_LIBRARY_PATH="/Users/runner/work/talib-prebuilt/talib-prebuilt/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
+            export DYLD_LIBRARY_PATH="/Users/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
       - name: Set wheel name
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   TALIB_C_VER: ${{ github.ref_name }}
-  TALIB_PY_VER: 0.6.0
+  TALIB_PY_VER: ${{ github.ref_name }}
 
 jobs:
   build_manylinux_x86_64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,304 @@
+
+name: TA-Lib-python GitHub Actions to build wheels
+run-name: TA-Lib-python GitHub Actions to build wheels
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  TALIB_C_VER: ${{ github.ref_name }}
+  TALIB_PY_VER: 0.6.0
+
+jobs:
+  build_manylinux_x86_64:
+    name: Build ManyLinux x86_64 wheels
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04"]
+    runs-on: ${{ matrix.os }}
+    env:
+      PIP_NO_VERIFY: 0
+      PIP_VERBOSE: 1
+      CIBW_BUILD_VERBOSITY: 2
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_I686_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_PYPY_I686_IMAGE: manylinux_2_28
+      CIBW_BEFORE_BUILD: pip install setuptools==58.0.1&&pip install -U Cython&&pip install -U wheel numpy
+      CIBW_BEFORE_TEST: pip install -U Cython
+      CIBW_TEST_REQUIRES: pytest pandas polars
+      CIBW_TEST_COMMAND: >
+        cd .. &&
+        pytest -k "not RSI and not threading" {project}/tests
+      CIBW_TEST_SKIP: "*win32 cp*"
+      CIBW_SKIP: "pp* cp*-musllinux*"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install GCC and CMake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc g++ cmake
+      - name: Make script executable
+        run: chmod +x build_linux.sh
+      - name: Build TA-Lib
+        run: ./tools/build_wheel_linux.sh
+        shell: bash
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ENVIRONMENT_LINUX : >
+            TA_LIBRARY_PATH="ta-lib-install/lib"
+            TA_INCLUDE_PATH="ta-lib-install/include"
+            PIP_NO_BUILD_ISOLATION=false
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            export LD_LIBRARY_PATH="/project/ta-lib-install/lib:$LD_LIBRARY_PATH"
+            auditwheel repair -w {dest_dir} {wheel}
+      - name: Set wheel name
+        run: |
+          echo "WHEEL_NAME=ta_lib-${{env.TALIB_PY_VER}}-manylinux_x86_64" >> $GITHUB_ENV
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}
+  build_musllinux_x86_64:
+    name: Build MuslLinux x86_64 wheels
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04"]
+    runs-on: ${{ matrix.os }}
+    env:
+      PIP_NO_VERIFY: 0
+      PIP_VERBOSE: 1
+      CIBW_BUILD_VERBOSITY: 2
+      CIBW_BEFORE_BUILD: pip install setuptools==58.0.1&&pip install Cython==0.29.37&&pip install -U wheel numpy
+      CIBW_BEFORE_TEST: apk add bash&&bash setup_rust.sh&&. "$HOME/.cargo/env"&&pip install Cython==0.29.37&&pip install -U maturin&&pip install -U polars
+      CIBW_TEST_REQUIRES: pytest pandas polars
+      CIBW_TEST_COMMAND: >
+        cd .. &&
+        pytest -k "not RSI and not threading" {project}/tests
+      CIBW_TEST_SKIP: "*win32 cp*"
+      CIBW_SKIP: "pp* cp*-manylinux*"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup latest Alpine Linux
+        uses: jirutka/setup-alpine@v1
+        with:
+          branch: v3.15
+          packages: >
+            build-base
+            bash
+            curl
+            unzip
+            gcc
+            g++
+            cmake
+          volumes: ${{ github.workspace }}:/project
+      - name: Make script executable
+        run: chmod +x build_linux.sh
+      - name: Build TA-Lib
+        run: |
+          ./tools/build_wheel_linux.sh
+        shell: alpine.sh {0}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BUILD_FRONTEND: build
+          CIBW_ENVIRONMENT_LINUX : >
+            TA_LIBRARY_PATH="ta-lib-install/lib"
+            TA_INCLUDE_PATH="ta-lib-install/include"
+            PIP_NO_BUILD_ISOLATION=false
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: |
+            export LD_LIBRARY_PATH="/project/ta-lib-install/lib:$LD_LIBRARY_PATH"
+            auditwheel repair -w {dest_dir} {wheel}
+      - name: Set wheel name
+        run: |
+          echo "WHEEL_NAME=ta_lib-${{env.TALIB_PY_VER}}-musllinux_x86_64" >> $GITHUB_ENV
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}
+  build_windows_amd64:
+    name: Build Windows amd64 wheels
+    strategy:
+      matrix:
+        os: ["windows-2022"]
+    runs-on: ${{ matrix.os }}
+    env:
+      MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT: 1
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Set up MSVC for x64
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+      - name: Build TA-Lib C library
+        run: tools/build_wheel_windows.cmd
+        shell: cmd
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          PIP_NO_VERIFY: 0
+          PIP_VERBOSE: 1
+          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BEFORE_BUILD: pip install -U setuptools wheel numpy Cython
+          CIBW_TEST_REQUIRES: pytest pandas polars
+          CIBW_TEST_COMMAND: >
+            cd .. &&
+            pytest --rootdir=C: -k "not RSI and not threading" {project}/tests
+          CIBW_TEST_SKIP: "*win32*"
+          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ENVIRONMENT_WINDOWS: >
+            TA_LIBRARY_PATH="ta-lib-$TALIB_C_VER\\_build;$LIB"
+            TA_INCLUDE_PATH="ta-lib-$TALIB_C_VER\\include;$INCLUDE"
+            PIP_NO_BUILD_ISOLATION=false
+      - name: Set wheel name
+        run: |
+          echo ("WHEEL_NAME=" + "ta_lib-" + $env:TALIB_PY_VER + "-win_amd64") >> $env:GITHUB_ENV
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}
+  build_windows_x86:
+    name: Build Windows x86 wheels
+    strategy:
+      matrix:
+        os: ["windows-2022"]
+    runs-on: ${{ matrix.os }}
+    env:
+      MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT: 1
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Set up MSVC for x86
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+      - name: Build TA-Lib C library
+        run: tools/build_wheel_windows.cmd
+        shell: cmd
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          PIP_NO_VERIFY: 0
+          PIP_VERBOSE: 1
+          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BEFORE_BUILD: pip install -U setuptools wheel numpy Cython
+          CIBW_TEST_REQUIRES: pytest pandas polars
+          CIBW_TEST_COMMAND: >
+            cd .. &&
+            pytest --rootdir=C: -k "not RSI and not threading" {project}/tests
+          CIBW_TEST_SKIP: "*win32 cp*"
+          CIBW_SKIP: "pp*"
+          MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT: 1
+          CIBW_ARCHS_WINDOWS: x86
+          CIBW_ENVIRONMENT_WINDOWS: >
+            TA_LIBRARY_PATH="ta-lib-$TALIB_C_VER\\_build;$LIB"
+            TA_INCLUDE_PATH="ta-lib-$TALIB_C_VER\\include;$INCLUDE"
+            PIP_NO_BUILD_ISOLATION=false
+      - name: Set wheel name
+        run: |
+          echo ("WHEEL_NAME=" + "ta_lib-" + $env:TALIB_PY_VER + "-win32") >> $env:GITHUB_ENV
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}
+  build_macos_x86_64:
+    name: Build MacOS x86_64 wheels
+    strategy:
+      matrix:
+        os: [macos-13]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Make script executable
+        run: chmod +x build_macos.sh
+      - name: Build TA-Lib
+        run: ./tools/build_wheel_macos.sh
+        shell: bash
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          PIP_NO_VERIFY: 0
+          PIP_VERBOSE: 1
+          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BEFORE_BUILD: python -c "import sys; from subprocess import call; call(['pip', 'install', 'setuptools==58.0.1' if sys.version_info <= (3, 11) else '-U', 'setuptools'])"&&pip install -U wheel numpy Cython
+          CIBW_TEST_REQUIRES: pytest pandas polars
+          CIBW_TEST_COMMAND: >
+            cd .. &&
+            pytest -k "not RSI and not threading" {project}/tests
+          CIBW_TEST_SKIP: "*win32 cp*"
+          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_MACOS: x86_64
+          CIBW_ENVIRONMENT_MACOS : >
+            TA_LIBRARY_PATH="ta-lib-install/lib"
+            TA_INCLUDE_PATH="ta-lib-install/include"
+            PIP_NO_BUILD_ISOLATION=false
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            export MACOSX_DEPLOYMENT_TARGET=13.7
+            export DYLD_LIBRARY_PATH="/Users/runner/work/talib-prebuilt/talib-prebuilt/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+      - name: Set wheel name
+        run: |
+          echo "WHEEL_NAME=ta_lib-${{env.TALIB_PY_VER}}-macos_x86_64" >> $GITHUB_ENV
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}
+  build_macos_arm64:
+    name: Build MacOS arm64 wheels
+    strategy:
+      matrix:
+        os: [macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Make script executable
+        run: chmod +x build_macos.sh
+      - name: Build TA-Lib
+        run: ./tools/build_wheel_macos.sh
+        shell: bash
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          PIP_NO_VERIFY: 0
+          PIP_VERBOSE: 1
+          CIBW_BUILD_VERBOSITY: 2
+          CIBW_BEFORE_BUILD: python -c "import sys; from subprocess import call; call(['pip', 'install', 'setuptools==58.0.1' if sys.version_info <= (3, 11) else '-U', 'setuptools'])"&&pip install -U wheel numpy Cython
+          CIBW_TEST_REQUIRES: pytest pandas polars
+          CIBW_TEST_COMMAND: >
+            cd .. &&
+            pytest -k "not RSI and not threading" {project}/tests
+          CIBW_TEST_SKIP: "*win32 cp*"
+          CIBW_SKIP: "pp*"
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_ENVIRONMENT_MACOS : >
+            TA_LIBRARY_PATH="ta-lib-install/lib"
+            TA_INCLUDE_PATH="ta-lib-install/include"
+            PIP_NO_BUILD_ISOLATION=false
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            export MACOSX_DEPLOYMENT_TARGET=14.0
+            export DYLD_LIBRARY_PATH="/Users/runner/work/talib-prebuilt/talib-prebuilt/ta-lib-install/lib:$DYLD_LIBRARY_PATH"
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+      - name: Set wheel name
+        run: |
+          echo "WHEEL_NAME=ta_lib-${{env.TALIB_PY_VER}}-macosx_arm64" >> $GITHUB_ENV
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: ${{ env.WHEEL_NAME }}

--- a/tools/build_wheel_linux.sh
+++ b/tools/build_wheel_linux.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# TALIB_C_VER=0.6.2
+# TALIB_PY_VER=0.5.2
+CMAKE_GENERATOR="Unix Makefiles"
+CMAKE_BUILD_TYPE=Release
+CMAKE_CONFIGURATION_TYPES=Release
+
+# Download TA-Lib C Library
+curl -L -o talib-c.zip https://github.com/TA-Lib/ta-lib/archive/refs/tags/v${TALIB_C_VER}.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to download TA-Lib C library"
+    exit 1
+fi
+
+# Download TA-Lib Python
+curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-${TALIB_PY_VER}.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to download TA-Lib Python library"
+    exit 1
+fi
+
+# Unzip TA-Lib C
+unzip -q talib-c.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to extract TA-Lib C library"
+    exit 1
+fi
+
+# Unzip TA-Lib Python
+unzip -q talib-python.zip -d ta-lib-python
+if [ $? -ne 0 ]; then
+    echo "Failed to extract TA-Lib Python library"
+    exit 1
+fi
+
+mv ta-lib-python/ta-lib-python-TA_Lib-${TALIB_PY_VER}/* .
+rm -r ta-lib-python
+
+# cd to TA-Lib C
+cd ta-lib-${TALIB_C_VER}
+
+# Copy TA-Lib C headers to TA-Lib Python
+mkdir -p include/ta-lib/
+cp include/*.h include/ta-lib/
+
+# Create build directory
+mkdir -p _build
+cd _build
+
+# Use CMake to configure the build
+cmake -G "$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_INSTALL_PREFIX=../../ta-lib-install ..
+if [ $? -ne 0 ]; then
+    echo "CMake configuration failed"
+    exit 1
+fi
+
+# Compile TA-Lib
+make
+if [ $? -ne 0 ]; then
+    echo "Build failed"
+    exit 1
+fi
+
+make install
+if [ $? -ne 0 ]; then
+    echo "Install failed"
+    exit 1
+fi
+
+echo "TA-Lib build completed successfully!"

--- a/tools/build_wheel_linux.sh
+++ b/tools/build_wheel_linux.sh
@@ -13,29 +13,12 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Download TA-Lib Python
-curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-${TALIB_PY_VER}.zip
-if [ $? -ne 0 ]; then
-    echo "Failed to download TA-Lib Python library"
-    exit 1
-fi
-
 # Unzip TA-Lib C
 unzip -q talib-c.zip
 if [ $? -ne 0 ]; then
     echo "Failed to extract TA-Lib C library"
     exit 1
 fi
-
-# Unzip TA-Lib Python
-unzip -q talib-python.zip -d ta-lib-python
-if [ $? -ne 0 ]; then
-    echo "Failed to extract TA-Lib Python library"
-    exit 1
-fi
-
-mv ta-lib-python/ta-lib-python-TA_Lib-${TALIB_PY_VER}/* .
-rm -r ta-lib-python
 
 # cd to TA-Lib C
 cd ta-lib-${TALIB_C_VER}

--- a/tools/build_wheel_macos.sh
+++ b/tools/build_wheel_macos.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# TALIB_C_VER=0.6.2
+# TALIB_PY_VER=0.5.2
+CMAKE_GENERATOR="Unix Makefiles"
+CMAKE_BUILD_TYPE=Release
+CMAKE_CONFIGURATION_TYPES=Release
+
+# Download TA-Lib C Library
+curl -L -o talib-c.zip https://github.com/TA-Lib/ta-lib/archive/refs/tags/v${TALIB_C_VER}.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to download TA-Lib C library"
+    exit 1
+fi
+
+# Download TA-Lib Python
+curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-${TALIB_PY_VER}.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to download TA-Lib Python library"
+    exit 1
+fi
+
+# Unzip TA-Lib C
+unzip -q talib-c.zip
+if [ $? -ne 0 ]; then
+    echo "Failed to extract TA-Lib C library"
+    exit 1
+fi
+
+# Unzip TA-Lib Python
+unzip -q talib-python.zip -d ta-lib-python
+if [ $? -ne 0 ]; then
+    echo "Failed to extract TA-Lib Python library"
+    exit 1
+fi
+
+mv ta-lib-python/ta-lib-python-TA_Lib-${TALIB_PY_VER}/* .
+rm -r ta-lib-python
+
+# cd to TA-Lib C
+cd ta-lib-${TALIB_C_VER}
+
+# Copy TA-Lib C headers to TA-Lib Python
+mkdir -p include/ta-lib/
+cp include/*.h include/ta-lib/
+
+# Create build directory
+mkdir -p _build
+cd _build
+
+# Use CMake to configure the build
+cmake -G "$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DCMAKE_INSTALL_PREFIX=../../ta-lib-install ..
+if [ $? -ne 0 ]; then
+    echo "CMake configuration failed"
+    exit 1
+fi
+
+# Compile TA-Lib
+make
+if [ $? -ne 0 ]; then
+    echo "Build failed"
+    exit 1
+fi
+
+make install
+if [ $? -ne 0 ]; then
+    echo "Install failed"
+    exit 1
+fi
+
+echo "TA-Lib build completed successfully!"

--- a/tools/build_wheel_macos.sh
+++ b/tools/build_wheel_macos.sh
@@ -13,29 +13,12 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Download TA-Lib Python
-curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-${TALIB_PY_VER}.zip
-if [ $? -ne 0 ]; then
-    echo "Failed to download TA-Lib Python library"
-    exit 1
-fi
-
 # Unzip TA-Lib C
 unzip -q talib-c.zip
 if [ $? -ne 0 ]; then
     echo "Failed to extract TA-Lib C library"
     exit 1
 fi
-
-# Unzip TA-Lib Python
-unzip -q talib-python.zip -d ta-lib-python
-if [ $? -ne 0 ]; then
-    echo "Failed to extract TA-Lib Python library"
-    exit 1
-fi
-
-mv ta-lib-python/ta-lib-python-TA_Lib-${TALIB_PY_VER}/* .
-rm -r ta-lib-python
 
 # cd to TA-Lib C
 cd ta-lib-${TALIB_C_VER}

--- a/tools/build_wheel_windows.cmd
+++ b/tools/build_wheel_windows.cmd
@@ -11,13 +11,7 @@ set CMAKE_CONFIGURATION_TYPES=Release
 curl -L -o talib-c.zip https://github.com/TA-Lib/ta-lib/archive/refs/tags/v%TALIB_C_VER%.zip
 if errorlevel 1 exit /B 1
 
-curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-%TALIB_PY_VER%.zip
-if errorlevel 1 exit /B 1
-
 tar -xzvf talib-c.zip
-if errorlevel 1 exit /B 1
-
-tar -xf talib-python.zip --strip-components=1
 if errorlevel 1 exit /B 1
 
 :: git apply --verbose --binary talib.diff

--- a/tools/build_wheel_windows.cmd
+++ b/tools/build_wheel_windows.cmd
@@ -1,0 +1,45 @@
+:: Download and build TA-Lib 
+@echo on
+
+:: set TALIB_C_VER=0.6.2
+:: set TALIB_PY_VER=0.5.2
+
+set CMAKE_GENERATOR=NMake Makefiles
+set CMAKE_BUILD_TYPE=Release
+set CMAKE_CONFIGURATION_TYPES=Release
+
+curl -L -o talib-c.zip https://github.com/TA-Lib/ta-lib/archive/refs/tags/v%TALIB_C_VER%.zip
+if errorlevel 1 exit /B 1
+
+curl -L -o talib-python.zip https://github.com/TA-Lib/ta-lib-python/archive/refs/tags/TA_Lib-%TALIB_PY_VER%.zip
+if errorlevel 1 exit /B 1
+
+tar -xzvf talib-c.zip
+if errorlevel 1 exit /B 1
+
+tar -xf talib-python.zip --strip-components=1
+if errorlevel 1 exit /B 1
+
+:: git apply --verbose --binary talib.diff
+:: if errorlevel 1 exit /B 1
+
+:: set MSBUILDTREATHIGHERTOOLSVERSIONASCURRENT
+
+setlocal
+cd ta-lib-%TALIB_C_VER%
+
+mkdir  include\ta-lib
+copy /Y include\*.* include\ta-lib
+
+md _build
+cd _build
+
+cmake.exe ..
+if errorlevel 1 exit /B 1
+
+nmake.exe /nologo all
+if errorlevel 1 exit /B 1
+
+copy /Y /B ta-lib-static.lib ta-lib.lib
+
+endlocal


### PR DESCRIPTION
I am trying to build wheels TA-Lib across multiple platforms and architectures with  GitHub Actions workflow. The workflow is triggered when a new tag starting with v* is pushed.

The workflow builds wheels for:
* Linux: ManyLinux (x86_64) and MuslLinux (x86_64)
* Windows: AMD64 and x86
* macOS: x86_64 and arm64

PR Details:
* add `build_wheel_windows.cmd`, `build_wheel_linux.sh` and `build_wheel_linux.sh` under the tools folder
* add `build.yml` under the workflow using pypa/cibuildwheel to handle the wheel-building process.

Currently, the workflow uploads the built wheels as GitHub artifacts. The PyPI Uploading or Github Release Uploading steps are not yet implemented.

Additionally, since the project already has a test workflow, I skipped all tests to speed up the build process (running tests would take five to six hours to build wheels for all platforms).
One of the reasons is that many platforms require building the test dependency (such as polars and numpy) from source.