### PR TITLE
Fix .pxd files missing is source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include COPYRIGHT
 include README.md
 include talib/*.c
 include talib/*.pyx
+include talib/*.pxd
 include talib/*.pxi
 include tests/*.py


### PR DESCRIPTION
The `_ta_lib.pxd` and `common.pxd` files are missing in the source distribution, `ta_lib-0.6.6.tar.gz`, on PyPI and GitHub, such that building from source fails.

```
  running build_ext
  Error compiling Cython file:
  ------------------------------------------------------------
  ...
  cimport _ta_lib as lib
          ^
  ------------------------------------------------------------
  talib\_common.pxi:1:8: '_ta_lib.pxd' not found
```