### PR TITLE
chore: don't depend on pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "build",
     "cython",
     "numpy",
-    "pip",
 ]
 requires-python = '>=3.9'
 


### PR DESCRIPTION
packages shouldn't usually depend on pip unless they actually need it (import from it etc).

currently - when installing ta-lib in an uv venv (which usually doensn't come with pip) - pip is installed as dependency of ta-lib.

to reproduce:
```
uv venv
. .venv/bin/activate
uv pip install ta-lib
uv pip show pip
```

which outputs:
```
Name: pip
Version: 25.2
Location: /home/xmatt/devel/.venv/lib/python3.13/site-packages
Requires:
Required-by: ta-lib    <-- pip is only installed due to ta-lib
```

if dependencies of pip were required (there ain't any) - then these should be listed instead.
