### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy"]
+requires = ["setuptools", "Cython", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -34,7 +34,6 @@ classifiers = [
     "Intended Audience :: Financial and Insurance Industry",
 ]
 dependencies = [
-    "build",
     "numpy",
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Remove the `wheel` build (backend) dependency, since it is not necessary (new versions of setuptools don't need it, old versions pull it automatically).

Remove the `build` runtime dependency. The `build` package is a frontend used in development workflows, and it neither needs to be installed when installing the package from a wheel, nor it needs to be kept once it's installed.